### PR TITLE
docs: fix simple typo, expliticly -> explicitly

### DIFF
--- a/async/example-codelock.c
+++ b/async/example-codelock.c
@@ -141,7 +141,7 @@ codelock_thread(struct async *pt)
 
   /*
    * We'll let the async loop until the async is
-   * expliticly exited with async_exit.
+   * explicitly exited with async_exit.
    */
   while(1) {
 


### PR DESCRIPTION
There is a small typo in async/example-codelock.c.

Should read `explicitly` rather than `expliticly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md