### PR TITLE
Add ASYNC wrapper macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Function|Description
 --------|-----------
 *async_begin(state)*|Mark the beginning of an async subroutine
 *async_end*|Mark the end of an async subroutine
+*ASYNC(state, ...code block...)*|Wrap the code block with async_begin and async_end automatically
 *async_yield*|Yield execution until it's invoked again
 *await(cond)*|Block progress until `cond` is true
 *await_while(cond)*|Block progress while `cond` is true
@@ -94,29 +95,29 @@ typedef struct {
 example_state pt;
 
 async nested(struct async *pt){
-    async_begin(pt);
+    ASYNC(pt, {
     ...
-    async_end;
+    });
 }
 
 async example(example_state *pt) {
-    async_begin(pt);
+    ASYNC(pt, {
 
-    // fork two nested async subroutines and wait until both complete
-    async_init(&pt->nested1);
-    async_init(&pt->nested2);
-    await(async_call(nested, &pt->nested1) & async_call(nested, &pt->nested2));
-    // OR call directly:
-    //await(nested(&pt->nested1) & nested(&pt->nested2));
-    
-    // fork two nested async subroutines and wait until at least one completes
-    async_init(&pt->nested1);
-    async_init(&pt->nested2);
-    await(async_call(nested, &pt->nested1) | async_call(nested, &pt->nested2));
-    // OR call the subroutines directly:
-    //await(nested(&pt->nested1) | nested(&pt->nested2));
+        // fork two nested async subroutines and wait until both complete
+        async_init(&pt->nested1);
+        async_init(&pt->nested2);
+        await(async_call(nested, &pt->nested1) & async_call(nested, &pt->nested2));
+        // OR call directly:
+        //await(nested(&pt->nested1) & nested(&pt->nested2));
+        
+        // fork two nested async subroutines and wait until at least one completes
+        async_init(&pt->nested1);
+        async_init(&pt->nested2);
+        await(async_call(nested, &pt->nested1) | async_call(nested, &pt->nested2));
+        // OR call the subroutines directly:
+        //await(nested(&pt->nested1) | nested(&pt->nested2));
 
-    async_end;
+    });
 }
 ```
 

--- a/async/async.h
+++ b/async/async.h
@@ -92,6 +92,14 @@ struct async { async_state; };
 #define async_end *_async_k=ASYNC_DONE; case ASYNC_DONE: return ASYNC_DONE; }
 
 /**
+ * Wrap code with async_begin/async_end.
+ * 
+ * @param state The async procedure state
+ * @param ... The code block to wrap
+ */
+#define ASYNC(state, ...) async_begin(state); __VA_ARGS__ async_end
+
+/**
  * Wait until the condition succeeds
  * @param cond The condition that must be satisfied before execution can proceed
  */


### PR DESCRIPTION
A tidy way to wrap an async function with the state initialization and close off the switch with the ASYNC_DONE